### PR TITLE
fix: indexOf method error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2047,7 +2047,7 @@ function getPath(rootNode, startingNode) {
 
   while(currentNode !== rootNode) {
     const parentNode = currentNode.parentElement;
-    const childIndex = parentNode.children.indexOf(currentNode); // We only care about the index
+    const childIndex = Array.from(parentNode.children).indexOf(currentNode); // We only care about the index
 
     path.push(childIndex);
 


### PR DESCRIPTION
First, thank you for this repo, very helpful. I found there's an `indexOf` method error when using it to find the index of a child. Because the `children` is a `NodeList` not an `Array`, therefore I send this PR for fixing the issue.