### PR TITLE
Add PracHub to Practice questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Keep each story to ~2 minutes, with measurable outcomes.
 - [Exercism](https://exercism.org/)
 - [NeetCode problem roadmap](https://neetcode.io/roadmap)
 - [Project Euler](https://projecteuler.net/)
+- [PracHub](https://prachub.com)
 
 ## Videos
 


### PR DESCRIPTION
Adds **PracHub** (https://prachub.com) to the Practice questions list, alongside LeetCode, HackerRank, and NeetCode.

PracHub is a free platform for practicing real tech-interview questions from 400+ companies — coding/DSA, SQL, system design, and behavioral — with an in-browser coding console. Same category as the other entries in this section.

Single-line addition, existing format preserved.